### PR TITLE
Add `fmt_install()` to register new specifier characters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ You do not need to use pico-sdk to use `pico_fmt`.
  - The CMake function `pico_set_printf_implementation()` may be called
    on an OBJECT_LIBRARY, not just an EXECUTABLE.
 
+ - New specifier characters (`%x`) may be registered with the
+   `fmt_install()` function, similar to GNU
+   `register_printf_specifier()` or Plan 9 `fmtinstall()`.
+
 # Usage
 
 ## Without pico-sdk
@@ -130,6 +134,15 @@ int printf(const char *format, ...) {
 
 I dislike Bazel even more than I dislike CMake; I do not provide Bazel
 build files for pico-fmt (but contributions welcome!).
+
+# Extending
+
+In the `%[flags][width][.precision][size]specifier` syntax, new
+specifier characters may be registered by including
+`<pico/fmt_install.h>` and calling `fmt_install()`.  See
+`fmt_install.h` for details.
+
+TODO: Write an example.
 
 # License
 

--- a/pico_fmt/CMakeLists.txt
+++ b/pico_fmt/CMakeLists.txt
@@ -14,6 +14,7 @@ if (NOT TARGET pico_fmt)
 
     target_sources(pico_fmt INTERFACE
             ${CMAKE_CURRENT_LIST_DIR}/printf.c
+            ${CMAKE_CURRENT_LIST_DIR}/convenience.c
     )
     target_link_libraries(pico_fmt INTERFACE pico_fmt_headers)
 

--- a/pico_fmt/convenience.c
+++ b/pico_fmt/convenience.c
@@ -1,0 +1,69 @@
+// Copyright (c) 2014-2019  Marco Paland (info@paland.com)
+// SPDX-License-Identifier: MIT
+//
+// Copyright (c) 2020  Raspberry Pi (Trading) Ltd.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Copyright (C) 2025  Luke T. Shumaker <lukeshu@lukeshu.com>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "pico/fmt_printf.h"
+
+// Outputs /////////////////////////////////////////////////////////////////////
+
+typedef struct {
+    char        *buffer;
+    size_t       maxlen;
+    size_t       cur;
+} _arg_buffer;
+
+static void _out_buffer(char character, void *_arg) {
+    _arg_buffer *arg = _arg;
+    if (arg->cur < arg->maxlen) {
+        arg->buffer[arg->cur++] = character;
+    }
+}
+
+// va_list wrappers ////////////////////////////////////////////////////////////
+
+int fmt_vsnprintf(char *buffer, size_t count, const char *format, va_list va) {
+    _arg_buffer arg = {
+        .buffer = buffer,
+        .maxlen = count,
+        .cur = 0,
+    };
+    const int ret = fmt_vfctprintf(buffer && count ? _out_buffer : NULL, &arg, format, va);
+    if (buffer && count)
+        buffer[arg.cur < count ? arg.cur : count-1] = '\0'; // nul-terminate
+    return ret;
+}
+
+int fmt_vsprintf(char *buffer, const char *format, va_list va) {
+    return fmt_vsnprintf(buffer, (size_t) -1, format, va);
+}
+
+// Var-args wrappers ///////////////////////////////////////////////////////////
+
+int fmt_fctprintf(fmt_fct_t out, void *arg, const char *format, ...) {
+    va_list va;
+    va_start(va, format);
+    const int ret = fmt_vfctprintf(out, arg, format, va);
+    va_end(va);
+    return ret;
+}
+
+int fmt_snprintf(char *buffer, size_t count, const char *format, ...) {
+    va_list va;
+    va_start(va, format);
+    const int ret = fmt_vsnprintf(buffer, count, format, va);
+    va_end(va);
+    return ret;
+}
+
+int fmt_sprintf(char *buffer, const char *format, ...) {
+    va_list va;
+    va_start(va, format);
+    const int ret = fmt_vsprintf(buffer, format, va);
+    va_end(va);
+    return ret;
+}

--- a/pico_fmt/include/pico/fmt_install.h
+++ b/pico_fmt/include/pico/fmt_install.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2014-2019  Marco Paland (info@paland.com)
+// SPDX-License-Identifier: MIT
+//
+// Copyright (C) 2025  Luke T. Shumaker <lukeshu@lukeshu.com>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef _PICO_FMT_INSTALL_H
+#define _PICO_FMT_INSTALL_H
+
+#include <stdarg.h>
+
+#include "pico/fmt_printf.h"
+
+#ifdef __cplusplus
+//extern "C" {
+#endif
+
+// For implementing your custom specifier //////////////////////////////////////
+
+#define FMT_FLAG_ZEROPAD   (1U <<  0U) // '0'
+#define FMT_FLAG_LEFT      (1U <<  1U) // '-'
+#define FMT_FLAG_PLUS      (1U <<  2U) // '+'
+#define FMT_FLAG_SPACE     (1U <<  3U) // ' '
+#define FMT_FLAG_HASH      (1U <<  4U) // '#'
+#define FMT_FLAG_PRECISION (1U << 10U) // state.precision is set
+
+enum fmt_size {
+    FMT_SIZE_CHAR,      // "hh"
+    FMT_SIZE_SHORT,     // "h"
+    FMT_SIZE_DEFAULT,   // ""
+    FMT_SIZE_LONG,      // "l"
+    FMT_SIZE_LONG_LONG, // "ll"
+};
+
+struct _fmt_ctx;
+
+struct fmt_state {
+    // %[flags][width][.precision][size]specifier
+    unsigned int         flags;
+    unsigned int         width;
+    unsigned int         precision;
+    enum fmt_size        size;
+    char                 specifier;
+
+    va_list             *args;
+
+    struct _fmt_ctx     *ctx;
+};
+
+/**
+ * \brief The function signature that your custom handler must implement.
+ */
+typedef void (*fmt_specifier_t)(struct fmt_state);
+
+void fmt_state_putchar(struct fmt_state state, char character);
+
+/**
+ * \brief How many characters have been fmt_state_putchar()ed so far.
+ */
+size_t fmt_state_len(struct fmt_state state);
+
+// For installing that function ////////////////////////////////////////////////
+
+void fmt_install(char character, fmt_specifier_t fn);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/pico_fmt/printf.c
+++ b/pico_fmt/printf.c
@@ -729,199 +729,199 @@ int fmt_vfctprintf(fmt_fct_t fct, void *arg, const char *format, va_list _va) {
 }
 
 static void conv_int(struct fmt_state state) {
-                // set the base
-                unsigned int base;
-                if (state.specifier == 'x' || state.specifier == 'X') {
-                    base = 16U;
-                } else if (state.specifier == 'o') {
-                    base = 8U;
-                } else if (state.specifier == 'b') {
-                    base = 2U;
-                } else {
-                    base = 10U;
-                    state.flags &= ~FMT_FLAG_HASH;   // no hash for dec format
-                }
+    // set the base
+    unsigned int base;
+    if (state.specifier == 'x' || state.specifier == 'X') {
+        base = 16U;
+    } else if (state.specifier == 'o') {
+        base = 8U;
+    } else if (state.specifier == 'b') {
+        base = 2U;
+    } else {
+        base = 10U;
+        state.flags &= ~FMT_FLAG_HASH;   // no hash for dec format
+    }
 
-                // no plus or space flag for u, x, X, o, b
-                if ((state.specifier != 'i') && (state.specifier != 'd')) {
-                    state.flags &= ~(FMT_FLAG_PLUS | FMT_FLAG_SPACE);
-                }
+    // no plus or space flag for u, x, X, o, b
+    if ((state.specifier != 'i') && (state.specifier != 'd')) {
+        state.flags &= ~(FMT_FLAG_PLUS | FMT_FLAG_SPACE);
+    }
 
-                // ignore '0' flag when precision is given
-                if (state.flags & FMT_FLAG_PRECISION) {
-                    state.flags &= ~FMT_FLAG_ZEROPAD;
-                }
+    // ignore '0' flag when precision is given
+    if (state.flags & FMT_FLAG_PRECISION) {
+        state.flags &= ~FMT_FLAG_ZEROPAD;
+    }
 
-                // convert the integer
-                if ((state.specifier == 'i') || (state.specifier == 'd')) {
-                    // signed
-                    switch (state.size) {
+    // convert the integer
+    if ((state.specifier == 'i') || (state.specifier == 'd')) {
+        // signed
+        switch (state.size) {
 #if PICO_PRINTF_SUPPORT_LONG_LONG
-                        case FMT_SIZE_LONG_LONG: {
-                            const long long value = va_arg(*state.args, long long);
-                            _ntoa_long_long(state, (unsigned long long) (value > 0 ? value : 0 - value), value < 0, base);
-                            break;
-                        }
+            case FMT_SIZE_LONG_LONG: {
+                const long long value = va_arg(*state.args, long long);
+                _ntoa_long_long(state, (unsigned long long) (value > 0 ? value : 0 - value), value < 0, base);
+                break;
+            }
 #else
-                        case FMT_SIZE_LONG_LONG: // fall through
+            case FMT_SIZE_LONG_LONG: // fall through
 #endif
-                        case FMT_SIZE_LONG: {
-                            const long value = va_arg(*state.args, long);
-                            _ntoa_long(state, (unsigned long) (value > 0 ? value : 0 - value), value < 0, base);
-                            break;
-                        }
-                        case FMT_SIZE_DEFAULT: {
-                            const int value = va_arg(*state.args, int);
-                            _ntoa_long(state, (unsigned int) (value > 0 ? value : 0 - value), value < 0, base);
-                            break;
-                        }
-                        case FMT_SIZE_SHORT: {
-                            // 'short' is promoted to 'int' when passed through '...'; so we read it
-                            // with va_arg(*state.args, int), but then truncate it with casting.
-                            const int value = (short int) va_arg(*state.args, int);
-                            _ntoa_long(state, (unsigned int) (value > 0 ? value : 0 - value), value < 0, base);
-                            break;
-                        }
-                        case FMT_SIZE_CHAR: {
-                            // 'char' is promoted to 'int' when passed through '...'; so we read it
-                            // with va_arg(*state.args, int), but then truncate it with casting.
-                            const int value = (char) va_arg(*state.args, int);
-                            _ntoa_long(state, (unsigned int) (value > 0 ? value : 0 - value), value < 0, base);
-                            break;
-                        }
-                    }
-                } else {
-                    // unsigned
-                    switch (state.size) {
-                        case FMT_SIZE_LONG_LONG:
+            case FMT_SIZE_LONG: {
+                const long value = va_arg(*state.args, long);
+                _ntoa_long(state, (unsigned long) (value > 0 ? value : 0 - value), value < 0, base);
+                break;
+            }
+            case FMT_SIZE_DEFAULT: {
+                const int value = va_arg(*state.args, int);
+                _ntoa_long(state, (unsigned int) (value > 0 ? value : 0 - value), value < 0, base);
+                break;
+            }
+            case FMT_SIZE_SHORT: {
+                // 'short' is promoted to 'int' when passed through '...'; so we read it
+                // with va_arg(*state.args, int), but then truncate it with casting.
+                const int value = (short int) va_arg(*state.args, int);
+                _ntoa_long(state, (unsigned int) (value > 0 ? value : 0 - value), value < 0, base);
+                break;
+            }
+            case FMT_SIZE_CHAR: {
+                // 'char' is promoted to 'int' when passed through '...'; so we read it
+                // with va_arg(*state.args, int), but then truncate it with casting.
+                const int value = (char) va_arg(*state.args, int);
+                _ntoa_long(state, (unsigned int) (value > 0 ? value : 0 - value), value < 0, base);
+                break;
+            }
+        }
+    } else {
+        // unsigned
+        switch (state.size) {
+            case FMT_SIZE_LONG_LONG:
 #if PICO_PRINTF_SUPPORT_LONG_LONG
-                            _ntoa_long_long(state, va_arg(*state.args, unsigned long long), false, base);
-                            break;
+                _ntoa_long_long(state, va_arg(*state.args, unsigned long long), false, base);
+                break;
 #else
-                            // fall through
+                // fall through
 #endif
-                        case FMT_SIZE_LONG:
-                            _ntoa_long(state, va_arg(*state.args, unsigned long), false, base);
-                            break;
-                        case FMT_SIZE_DEFAULT:
-                            _ntoa_long(state, va_arg(*state.args, unsigned int), false, base);
-                            break;
-                        case FMT_SIZE_SHORT:
-                            // 'short' is promoted to 'int' when passed through '...'; so we read it
-                            // with va_arg(*state.args, unsigned int), but then truncate it with casting.
-                            _ntoa_long(state, (unsigned short int) va_arg(*state.args, unsigned int), false, base);
-                            break;
-                        case FMT_SIZE_CHAR:
-                            // 'char' is promoted to 'int' when passed through '...'; so we read it
-                            // with va_arg(*state.args, unsigned int), but then truncate it with casting.
-                            _ntoa_long(state, (unsigned char) va_arg(*state.args, unsigned int), false, base);
-                            break;
-                    }
-                }
+            case FMT_SIZE_LONG:
+                _ntoa_long(state, va_arg(*state.args, unsigned long), false, base);
+                break;
+            case FMT_SIZE_DEFAULT:
+                _ntoa_long(state, va_arg(*state.args, unsigned int), false, base);
+                break;
+            case FMT_SIZE_SHORT:
+                // 'short' is promoted to 'int' when passed through '...'; so we read it
+                // with va_arg(*state.args, unsigned int), but then truncate it with casting.
+                _ntoa_long(state, (unsigned short int) va_arg(*state.args, unsigned int), false, base);
+                break;
+            case FMT_SIZE_CHAR:
+                // 'char' is promoted to 'int' when passed through '...'; so we read it
+                // with va_arg(*state.args, unsigned int), but then truncate it with casting.
+                _ntoa_long(state, (unsigned char) va_arg(*state.args, unsigned int), false, base);
+                break;
+        }
+    }
 }
 
 static void conv_double(struct fmt_state state) {
     switch (state.specifier) {
-            case 'f' :
-            case 'F' :
+        case 'f' :
+        case 'F' :
 #if PICO_PRINTF_SUPPORT_FLOAT
-                {
-                    double value = va_arg(*state.args, double);
-                    // test for very large values
-                    // standard printf behavior is to print EVERY whole number digit -- which could be 100s of characters overflowing your buffers == bad
-                    if ((value > PICO_PRINTF_MAX_FLOAT && value < DBL_MAX)
-                        || (value < -PICO_PRINTF_MAX_FLOAT && value > -DBL_MAX)) {
+            {
+                double value = va_arg(*state.args, double);
+                // test for very large values
+                // standard printf behavior is to print EVERY whole number digit -- which could be 100s of characters overflowing your buffers == bad
+                if ((value > PICO_PRINTF_MAX_FLOAT && value < DBL_MAX)
+                    || (value < -PICO_PRINTF_MAX_FLOAT && value > -DBL_MAX)) {
 #if PICO_PRINTF_SUPPORT_EXPONENTIAL
-                        _etoa(state, value, false);
+                    _etoa(state, value, false);
 #endif
-                        break;
-                    }
-                    _ftoa(state, value);
+                    break;
                 }
+                _ftoa(state, value);
+            }
 #else
-                for(int i=0;i<2;i++) out('?', state.ctx);
-                va_arg(*state.args, double);
+            for(int i=0;i<2;i++) out('?', state.ctx);
+            va_arg(*state.args, double);
 #endif
-                break;
-            case 'e':
-            case 'E':
+            break;
+        case 'e':
+        case 'E':
 #if PICO_PRINTF_SUPPORT_FLOAT && PICO_PRINTF_SUPPORT_EXPONENTIAL
-                _etoa(state, va_arg(*state.args, double), false);
+            _etoa(state, va_arg(*state.args, double), false);
 #else
-                for(int i=0;i<2;i++) out('?', state.ctx);
-                va_arg(*state.args, double);
+            for(int i=0;i<2;i++) out('?', state.ctx);
+            va_arg(*state.args, double);
 #endif
-                break;
-            case 'g':
-            case 'G':
+            break;
+        case 'g':
+        case 'G':
 #if PICO_PRINTF_SUPPORT_FLOAT && PICO_PRINTF_SUPPORT_EXPONENTIAL
-                _etoa(state, va_arg(*state.args, double), true);
+            _etoa(state, va_arg(*state.args, double), true);
 #else
-                for(int i=0;i<2;i++) out('?', state.ctx);
-                va_arg(*state.args, double);
+            for(int i=0;i<2;i++) out('?', state.ctx);
+            va_arg(*state.args, double);
 #endif
-                break;
+            break;
     }
 }
 
 static void conv_char(struct fmt_state state) {
-                unsigned int l = 1U;
-                // pre padding
-                if (!(state.flags & FMT_FLAG_LEFT)) {
-                    while (l++ < state.width) {
-                        out(' ', state.ctx);
-                    }
-                }
-                // char output
-                out((char) va_arg(*state.args, int), state.ctx);
-                // post padding
-                if (state.flags & FMT_FLAG_LEFT) {
-                    while (l++ < state.width) {
-                        out(' ', state.ctx);
-                    }
-                }
+    unsigned int l = 1U;
+    // pre padding
+    if (!(state.flags & FMT_FLAG_LEFT)) {
+        while (l++ < state.width) {
+            out(' ', state.ctx);
+        }
+    }
+    // char output
+    out((char) va_arg(*state.args, int), state.ctx);
+    // post padding
+    if (state.flags & FMT_FLAG_LEFT) {
+        while (l++ < state.width) {
+            out(' ', state.ctx);
+        }
+    }
 }
 
 static void conv_str(struct fmt_state state) {
-                const char *p = va_arg(*state.args, char*);
-                unsigned int l = _strnlen_s(p, state.precision ? state.precision : (size_t) -1);
-                // pre padding
-                if (state.flags & FMT_FLAG_PRECISION) {
-                    l = (l < state.precision ? l : state.precision);
-                }
-                if (!(state.flags & FMT_FLAG_LEFT)) {
-                    while (l++ < state.width) {
-                        out(' ', state.ctx);
-                    }
-                }
-                // string output
-                while ((*p != 0) && (!(state.flags & FMT_FLAG_PRECISION) || state.precision--)) {
-                    out(*(p++), state.ctx);
-                }
-                // post padding
-                if (state.flags & FMT_FLAG_LEFT) {
-                    while (l++ < state.width) {
-                        out(' ', state.ctx);
-                    }
-                }
+    const char *p = va_arg(*state.args, char*);
+    unsigned int l = _strnlen_s(p, state.precision ? state.precision : (size_t) -1);
+    // pre padding
+    if (state.flags & FMT_FLAG_PRECISION) {
+        l = (l < state.precision ? l : state.precision);
+    }
+    if (!(state.flags & FMT_FLAG_LEFT)) {
+        while (l++ < state.width) {
+            out(' ', state.ctx);
+        }
+    }
+    // string output
+    while ((*p != 0) && (!(state.flags & FMT_FLAG_PRECISION) || state.precision--)) {
+        out(*(p++), state.ctx);
+    }
+    // post padding
+    if (state.flags & FMT_FLAG_LEFT) {
+        while (l++ < state.width) {
+            out(' ', state.ctx);
+        }
+    }
 }
 
 static void conv_ptr(struct fmt_state state) {
-                state.width = sizeof(void *) * 2U;
-                state.flags |= FMT_FLAG_ZEROPAD;
-                state.specifier = 'X';
+    state.width = sizeof(void *) * 2U;
+    state.flags |= FMT_FLAG_ZEROPAD;
+    state.specifier = 'X';
 #if PICO_PRINTF_SUPPORT_LONG_LONG
-                const bool is_ll = sizeof(uintptr_t) == sizeof(long long);
-                if (is_ll) {
-                    _ntoa_long_long(state, (uintptr_t) va_arg(*state.args, void*), false, 16U);
-                } else {
+    const bool is_ll = sizeof(uintptr_t) == sizeof(long long);
+    if (is_ll) {
+        _ntoa_long_long(state, (uintptr_t) va_arg(*state.args, void*), false, 16U);
+    } else {
 #endif
-                    _ntoa_long(state, (unsigned long) ((uintptr_t) va_arg(*state.args, void*)), false, 16U);
+        _ntoa_long(state, (unsigned long) ((uintptr_t) va_arg(*state.args, void*)), false, 16U);
 #if PICO_PRINTF_SUPPORT_LONG_LONG
-                }
+    }
 #endif
 }
 
 static void conv_pct(struct fmt_state state) {
-                out('%', state.ctx);
+    out('%', state.ctx);
 }

--- a/pico_fmt/printf.c
+++ b/pico_fmt/printf.c
@@ -115,40 +115,18 @@
 
 #endif
 
-// output function type
-typedef void (*out_fct_type)(char character, void *buffer, size_t idx, size_t maxlen);
+struct ctx {
+    fmt_fct_t    fct;
+    void        *arg;
+    size_t       idx;
+};
 
-// wrapper (used as buffer) for output function type
-typedef struct {
-    fmt_fct_t fct;
-    void *arg;
-} out_fct_wrap_type;
-
-// internal buffer output
-static inline void _out_buffer(char character, void *buffer, size_t idx, size_t maxlen) {
-    if (idx < maxlen) {
-        ((char *) buffer)[idx] = character;
+static inline void out(char character, struct ctx *ctx) {
+    if (ctx->fct) {
+        ctx->fct(character, ctx->arg);
     }
+    ctx->idx++;
 }
-
-// internal null output
-static inline void _out_null(char character, void *buffer, size_t idx, size_t maxlen) {
-    (void) character;
-    (void) buffer;
-    (void) idx;
-    (void) maxlen;
-}
-
-// internal output function wrapper
-static inline void _out_fct(char character, void *buffer, size_t idx, size_t maxlen) {
-    (void) idx;
-    (void) maxlen;
-    if (character) {
-        // buffer is the output fct pointer
-        ((out_fct_wrap_type *) buffer)->fct(character, ((out_fct_wrap_type *) buffer)->arg);
-    }
-}
-
 
 // internal secure strlen
 // \return The length of the string (excluding the terminating 0) limited by 'maxsize'
@@ -177,37 +155,35 @@ static unsigned int _atoi(const char **str) {
 
 
 // output the specified string in reverse, taking care of any zero-padding
-static size_t _out_rev(out_fct_type out, char *buffer, size_t idx, size_t maxlen, const char *buf, size_t len,
-                       unsigned int width, unsigned int flags) {
-    const size_t start_idx = idx;
+static void _out_rev(struct ctx *ctx, const char *buf, size_t len,
+                     unsigned int width, unsigned int flags) {
+    const size_t start_idx = ctx->idx;
 
     // pad spaces up to given width
     if (!(flags & FLAGS_LEFT) && !(flags & FLAGS_ZEROPAD)) {
         for (size_t i = len; i < width; i++) {
-            out(' ', buffer, idx++, maxlen);
+            out(' ', ctx);
         }
     }
 
     // reverse string
     while (len) {
-        out(buf[--len], buffer, idx++, maxlen);
+        out(buf[--len], ctx);
     }
 
     // append pad spaces up to given width
     if (flags & FLAGS_LEFT) {
-        while (idx - start_idx < width) {
-            out(' ', buffer, idx++, maxlen);
+        while (ctx->idx - start_idx < width) {
+            out(' ', ctx);
         }
     }
-
-    return idx;
 }
 
 
 // internal itoa format
-static size_t _ntoa_format(out_fct_type out, char *buffer, size_t idx, size_t maxlen, char *buf, size_t len,
-                           bool negative, unsigned int base, unsigned int prec, unsigned int width,
-                           unsigned int flags) {
+static void _ntoa_format(struct ctx *ctx, char *buf, size_t len,
+                         bool negative, unsigned int base, unsigned int prec, unsigned int width,
+                         unsigned int flags) {
     // pad leading zeros
     if (!(flags & FLAGS_LEFT)) {
         if (width && (flags & FLAGS_ZEROPAD) && (negative || (flags & (FLAGS_PLUS | FLAGS_SPACE)))) {
@@ -251,13 +227,13 @@ static size_t _ntoa_format(out_fct_type out, char *buffer, size_t idx, size_t ma
         }
     }
 
-    return _out_rev(out, buffer, idx, maxlen, buf, len, width, flags);
+    _out_rev(ctx, buf, len, width, flags);
 }
 
 
 // internal itoa for 'long' type
-static size_t _ntoa_long(out_fct_type out, char *buffer, size_t idx, size_t maxlen, unsigned long value, bool negative,
-                         unsigned long base, unsigned int prec, unsigned int width, unsigned int flags) {
+static void _ntoa_long(struct ctx *ctx, unsigned long value, bool negative,
+                       unsigned long base, unsigned int prec, unsigned int width, unsigned int flags) {
     char buf[PICO_PRINTF_NTOA_BUFFER_SIZE];
     size_t len = 0U;
 
@@ -275,16 +251,16 @@ static size_t _ntoa_long(out_fct_type out, char *buffer, size_t idx, size_t maxl
         } while (value && (len < PICO_PRINTF_NTOA_BUFFER_SIZE));
     }
 
-    return _ntoa_format(out, buffer, idx, maxlen, buf, len, negative, (unsigned int) base, prec, width, flags);
+    _ntoa_format(ctx, buf, len, negative, (unsigned int) base, prec, width, flags);
 }
 
 
 // internal itoa for 'long long' type
 #if PICO_PRINTF_SUPPORT_LONG_LONG
 
-static size_t _ntoa_long_long(out_fct_type out, char *buffer, size_t idx, size_t maxlen, unsigned long long value,
-                              bool negative, unsigned long long base, unsigned int prec, unsigned int width,
-                              unsigned int flags) {
+static void _ntoa_long_long(struct ctx *ctx, unsigned long long value,
+                            bool negative, unsigned long long base, unsigned int prec, unsigned int width,
+                            unsigned int flags) {
     char buf[PICO_PRINTF_NTOA_BUFFER_SIZE];
     size_t len = 0U;
 
@@ -302,7 +278,7 @@ static size_t _ntoa_long_long(out_fct_type out, char *buffer, size_t idx, size_t
         } while (value && (len < PICO_PRINTF_NTOA_BUFFER_SIZE));
     }
 
-    return _ntoa_format(out, buffer, idx, maxlen, buf, len, negative, (unsigned int) base, prec, width, flags);
+    _ntoa_format(ctx, buf, len, negative, (unsigned int) base, prec, width, flags);
 }
 
 #endif  // PICO_PRINTF_SUPPORT_LONG_LONG
@@ -312,15 +288,15 @@ static size_t _ntoa_long_long(out_fct_type out, char *buffer, size_t idx, size_t
 
 #if PICO_PRINTF_SUPPORT_EXPONENTIAL
 // forward declaration so that _ftoa can switch to exp notation for values > PICO_PRINTF_MAX_FLOAT
-static size_t _etoa(out_fct_type out, char *buffer, size_t idx, size_t maxlen, double value, unsigned int prec,
-                    unsigned int width, unsigned int flags);
+static void _etoa(struct ctx *ctx, double value, unsigned int prec,
+                  unsigned int width, unsigned int flags);
 #endif
 
 #define is_nan __builtin_isnan
 
 // internal ftoa for fixed decimal floating point
-static size_t _ftoa(out_fct_type out, char *buffer, size_t idx, size_t maxlen, double value, unsigned int prec,
-                    unsigned int width, unsigned int flags) {
+static void _ftoa(struct ctx *ctx, double value, unsigned int prec,
+                  unsigned int width, unsigned int flags) {
     char buf[PICO_PRINTF_FTOA_BUFFER_SIZE];
     size_t len = 0U;
     double diff = 0.0;
@@ -329,22 +305,27 @@ static size_t _ftoa(out_fct_type out, char *buffer, size_t idx, size_t maxlen, d
     static const double pow10[] = {1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000};
 
     // test for special values
-    if (is_nan(value))
-        return _out_rev(out, buffer, idx, maxlen, "nan", 3, width, flags);
-    if (value < -DBL_MAX)
-        return _out_rev(out, buffer, idx, maxlen, "fni-", 4, width, flags);
-    if (value > DBL_MAX)
-        return _out_rev(out, buffer, idx, maxlen, (flags & FLAGS_PLUS) ? "fni+" : "fni", (flags & FLAGS_PLUS) ? 4U : 3U,
-                        width, flags);
+    if (is_nan(value)) {
+        _out_rev(ctx, "nan", 3, width, flags);
+        return;
+    }
+    if (value < -DBL_MAX) {
+        _out_rev(ctx, "fni-", 4, width, flags);
+        return;
+    }
+    if (value > DBL_MAX) {
+        _out_rev(ctx, (flags & FLAGS_PLUS) ? "fni+" : "fni", (flags & FLAGS_PLUS) ? 4U : 3U,
+                 width, flags);
+        return;
+    }
 
     // test for very large values
     // standard printf behavior is to print EVERY whole number digit -- which could be 100s of characters overflowing your buffers == bad
     if ((value > PICO_PRINTF_MAX_FLOAT) || (value < -PICO_PRINTF_MAX_FLOAT)) {
 #if PICO_PRINTF_SUPPORT_EXPONENTIAL
-        return _etoa(out, buffer, idx, maxlen, value, prec, width, flags);
-#else
-        return 0U;
+        _etoa(ctx, value, prec, width, flags);
 #endif
+        return;
     }
 
     // test for negative
@@ -437,18 +418,19 @@ static size_t _ftoa(out_fct_type out, char *buffer, size_t idx, size_t maxlen, d
         }
     }
 
-    return _out_rev(out, buffer, idx, maxlen, buf, len, width, flags);
+    _out_rev(ctx, buf, len, width, flags);
 }
 
 
 #if PICO_PRINTF_SUPPORT_EXPONENTIAL
 
 // internal ftoa variant for exponential floating-point type, contributed by Martijn Jasperse <m.jasperse@gmail.com>
-static size_t _etoa(out_fct_type out, char *buffer, size_t idx, size_t maxlen, double value, unsigned int prec,
-                    unsigned int width, unsigned int flags) {
+static void _etoa(struct ctx *ctx, double value, unsigned int prec,
+                  unsigned int width, unsigned int flags) {
     // check for NaN and special values
     if (is_nan(value) || (value > DBL_MAX) || (value < -DBL_MAX)) {
-        return _ftoa(out, buffer, idx, maxlen, value, prec, width, flags);
+        _ftoa(ctx, value, prec, width, flags);
+        return;
     }
 
     // determine the sign
@@ -536,42 +518,40 @@ static size_t _etoa(out_fct_type out, char *buffer, size_t idx, size_t maxlen, d
     }
 
     // output the floating part
-    const size_t start_idx = idx;
-    idx = _ftoa(out, buffer, idx, maxlen, negative ? -value : value, prec, fwidth, flags & ~FLAGS_ADAPT_EXP);
+    const size_t start_idx = ctx->idx;
+    _ftoa(ctx, negative ? -value : value, prec, fwidth, flags & ~FLAGS_ADAPT_EXP);
 
     // output the exponent part
     if (minwidth) {
         // output the exponential symbol
-        out((flags & FLAGS_UPPERCASE) ? 'E' : 'e', buffer, idx++, maxlen);
+        out((flags & FLAGS_UPPERCASE) ? 'E' : 'e', ctx);
         // output the exponent value
-        idx = _ntoa_long(out, buffer, idx, maxlen, (unsigned int)((expval < 0) ? -expval : expval), expval < 0, 10, 0, minwidth - 1,
-                         FLAGS_ZEROPAD | FLAGS_PLUS);
+        _ntoa_long(ctx, (unsigned int)((expval < 0) ? -expval : expval), expval < 0, 10, 0, minwidth - 1,
+                   FLAGS_ZEROPAD | FLAGS_PLUS);
         // might need to right-pad spaces
         if (flags & FLAGS_LEFT) {
-            while (idx - start_idx < width) out(' ', buffer, idx++, maxlen);
+            while (ctx->idx - start_idx < width) out(' ', ctx);
         }
     }
-    return idx;
 }
 
 #endif  // PICO_PRINTF_SUPPORT_EXPONENTIAL
 #endif  // PICO_PRINTF_SUPPORT_FLOAT
 
-// internal vsnprintf
-static int _vsnprintf(out_fct_type out, char *buffer, const size_t maxlen, const char *format, va_list va) {
+int fmt_vfctprintf(fmt_fct_t fct, void *arg, const char *format, va_list va) {
     unsigned int flags, width, precision, n;
-    size_t idx = 0U;
-
-    if (!buffer) {
-        // use null output function
-        out = _out_null;
-    }
+    struct ctx _ctx = {
+        .fct = fct,
+        .arg = arg,
+        .idx = 0,
+    };
+    struct ctx *ctx = &_ctx;
 
     while (*format) {
         // format specifier?  %[flags][width][.precision][length]
         if (*format != '%') {
             // no
-            out(*format, buffer, idx++, maxlen);
+            out(*format, ctx);
             format++;
             continue;
         } else {
@@ -721,38 +701,38 @@ static int _vsnprintf(out_fct_type out, char *buffer, const size_t maxlen, const
                     if (flags & FLAGS_LONG_LONG) {
 #if PICO_PRINTF_SUPPORT_LONG_LONG
                         const long long value = va_arg(va, long long);
-                        idx = _ntoa_long_long(out, buffer, idx, maxlen,
-                                              (unsigned long long) (value > 0 ? value : 0 - value), value < 0, base,
-                                              precision, width, flags);
+                        _ntoa_long_long(ctx,
+                                        (unsigned long long) (value > 0 ? value : 0 - value), value < 0, base,
+                                        precision, width, flags);
 #endif
                     } else if (flags & FLAGS_LONG) {
                         const long value = va_arg(va, long);
-                        idx = _ntoa_long(out, buffer, idx, maxlen, (unsigned long) (value > 0 ? value : 0 - value),
-                                         value < 0, base, precision, width, flags);
+                        _ntoa_long(ctx, (unsigned long) (value > 0 ? value : 0 - value),
+                                   value < 0, base, precision, width, flags);
                     } else {
                         const int value = (flags & FLAGS_CHAR) ? (char) va_arg(va, int) : (flags & FLAGS_SHORT)
                                                                                           ? (short int) va_arg(va, int)
                                                                                           : va_arg(va, int);
-                        idx = _ntoa_long(out, buffer, idx, maxlen, (unsigned int) (value > 0 ? value : 0 - value),
-                                         value < 0, base, precision, width, flags);
+                        _ntoa_long(ctx, (unsigned int) (value > 0 ? value : 0 - value),
+                                   value < 0, base, precision, width, flags);
                     }
                 } else {
                     // unsigned
                     if (flags & FLAGS_LONG_LONG) {
 #if PICO_PRINTF_SUPPORT_LONG_LONG
-                        idx = _ntoa_long_long(out, buffer, idx, maxlen, va_arg(va, unsigned long long), false, base,
-                                              precision, width, flags);
+                        _ntoa_long_long(ctx, va_arg(va, unsigned long long), false, base,
+                                        precision, width, flags);
 #endif
                     } else if (flags & FLAGS_LONG) {
-                        idx = _ntoa_long(out, buffer, idx, maxlen, va_arg(va, unsigned long), false, base, precision,
-                                         width, flags);
+                        _ntoa_long(ctx, va_arg(va, unsigned long), false, base, precision,
+                                   width, flags);
                     } else {
                         const unsigned int value = (flags & FLAGS_CHAR) ? (unsigned char) va_arg(va, unsigned int)
                                                                         : (flags & FLAGS_SHORT)
                                                                           ? (unsigned short int) va_arg(va,
                                                                                                         unsigned int)
                                                                           : va_arg(va, unsigned int);
-                        idx = _ntoa_long(out, buffer, idx, maxlen, value, false, base, precision, width, flags);
+                        _ntoa_long(ctx, value, false, base, precision, width, flags);
                     }
                 }
                 format++;
@@ -762,9 +742,9 @@ static int _vsnprintf(out_fct_type out, char *buffer, const size_t maxlen, const
             case 'F' :
 #if PICO_PRINTF_SUPPORT_FLOAT
                 if (*format == 'F') flags |= FLAGS_UPPERCASE;
-                idx = _ftoa(out, buffer, idx, maxlen, va_arg(va, double), precision, width, flags);
+                _ftoa(ctx, va_arg(va, double), precision, width, flags);
 #else
-                for(int i=0;i<2;i++) out('?', buffer, idx++, maxlen);
+                for(int i=0;i<2;i++) out('?', ctx);
                 va_arg(va, double);
 #endif
                 format++;
@@ -776,9 +756,9 @@ static int _vsnprintf(out_fct_type out, char *buffer, const size_t maxlen, const
 #if PICO_PRINTF_SUPPORT_FLOAT && PICO_PRINTF_SUPPORT_EXPONENTIAL
                 if ((*format == 'g') || (*format == 'G')) flags |= FLAGS_ADAPT_EXP;
                 if ((*format == 'E') || (*format == 'G')) flags |= FLAGS_UPPERCASE;
-                idx = _etoa(out, buffer, idx, maxlen, va_arg(va, double), precision, width, flags);
+                _etoa(ctx, va_arg(va, double), precision, width, flags);
 #else
-                for(int i=0;i<2;i++) out('?', buffer, idx++, maxlen);
+                for(int i=0;i<2;i++) out('?', ctx);
                 va_arg(va, double);
 #endif
                 format++;
@@ -788,15 +768,15 @@ static int _vsnprintf(out_fct_type out, char *buffer, const size_t maxlen, const
                 // pre padding
                 if (!(flags & FLAGS_LEFT)) {
                     while (l++ < width) {
-                        out(' ', buffer, idx++, maxlen);
+                        out(' ', ctx);
                     }
                 }
                 // char output
-                out((char) va_arg(va, int), buffer, idx++, maxlen);
+                out((char) va_arg(va, int), ctx);
                 // post padding
                 if (flags & FLAGS_LEFT) {
                     while (l++ < width) {
-                        out(' ', buffer, idx++, maxlen);
+                        out(' ', ctx);
                     }
                 }
                 format++;
@@ -812,17 +792,17 @@ static int _vsnprintf(out_fct_type out, char *buffer, const size_t maxlen, const
                 }
                 if (!(flags & FLAGS_LEFT)) {
                     while (l++ < width) {
-                        out(' ', buffer, idx++, maxlen);
+                        out(' ', ctx);
                     }
                 }
                 // string output
                 while ((*p != 0) && (!(flags & FLAGS_PRECISION) || precision--)) {
-                    out(*(p++), buffer, idx++, maxlen);
+                    out(*(p++), ctx);
                 }
                 // post padding
                 if (flags & FLAGS_LEFT) {
                     while (l++ < width) {
-                        out(' ', buffer, idx++, maxlen);
+                        out(' ', ctx);
                     }
                 }
                 format++;
@@ -835,12 +815,12 @@ static int _vsnprintf(out_fct_type out, char *buffer, const size_t maxlen, const
 #if PICO_PRINTF_SUPPORT_LONG_LONG
                 const bool is_ll = sizeof(uintptr_t) == sizeof(long long);
                 if (is_ll) {
-                    idx = _ntoa_long_long(out, buffer, idx, maxlen, (uintptr_t) va_arg(va, void*), false, 16U,
-                                          precision, width, flags);
+                    _ntoa_long_long(ctx, (uintptr_t) va_arg(va, void*), false, 16U,
+                                    precision, width, flags);
                 } else {
 #endif
-                    idx = _ntoa_long(out, buffer, idx, maxlen, (unsigned long) ((uintptr_t) va_arg(va, void*)), false,
-                                     16U, precision, width, flags);
+                    _ntoa_long(ctx, (unsigned long) ((uintptr_t) va_arg(va, void*)), false,
+                               16U, precision, width, flags);
 #if PICO_PRINTF_SUPPORT_LONG_LONG
                 }
 #endif
@@ -849,61 +829,16 @@ static int _vsnprintf(out_fct_type out, char *buffer, const size_t maxlen, const
             }
 
             case '%' :
-                out('%', buffer, idx++, maxlen);
+                out('%', ctx);
                 format++;
                 break;
 
             default :
-                out(*format, buffer, idx++, maxlen);
+                out(*format, ctx);
                 format++;
                 break;
         }
     }
 
-    // termination
-    out((char) 0, buffer, idx < maxlen ? idx : maxlen - 1U, maxlen);
-
-    // return written chars without terminating \0
-    return (int) idx;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-
-int fmt_vfctprintf(fmt_fct_t out, void *arg, const char *format, va_list va) {
-    const out_fct_wrap_type out_fct_wrap = {out, arg};
-    return _vsnprintf(_out_fct, (char *) (uintptr_t) &out_fct_wrap, (size_t) -1, format, va);
-}
-
-///////////////////////////////////////////////////////////////////////////////
-
-int fmt_fctprintf(fmt_fct_t out, void *arg, const char *format, ...) {
-    va_list va;
-    va_start(va, format);
-    const int ret = fmt_vfctprintf(out, arg, format, va);
-    va_end(va);
-    return ret;
-}
-
-int fmt_sprintf(char *buffer, const char *format, ...) {
-    va_list va;
-    va_start(va, format);
-    const int ret = _vsnprintf(_out_buffer, buffer, (size_t) -1, format, va);
-    va_end(va);
-    return ret;
-}
-
-int fmt_vsprintf(char *buffer, const char *format, va_list va) {
-    return _vsnprintf(_out_buffer, buffer, (size_t) -1, format, va);
-}
-
-int fmt_snprintf(char *buffer, size_t count, const char *format, ...) {
-    va_list va;
-    va_start(va, format);
-    const int ret = _vsnprintf(_out_buffer, buffer, count, format, va);
-    va_end(va);
-    return ret;
-}
-
-int fmt_vsnprintf(char *buffer, size_t count, const char *format, va_list va) {
-    return _vsnprintf(_out_buffer, buffer, count, format, va);
+    return (int) ctx->idx;
 }

--- a/pico_fmt/printf.c
+++ b/pico_fmt/printf.c
@@ -710,9 +710,9 @@ int fmt_vfctprintf(fmt_fct_t fct, void *arg, const char *format, va_list va) {
                         _ntoa_long(ctx, (unsigned long) (value > 0 ? value : 0 - value),
                                    value < 0, base, precision, width, flags);
                     } else {
-                        const int value = (flags & FLAGS_CHAR) ? (char) va_arg(va, int) : (flags & FLAGS_SHORT)
-                                                                                          ? (short int) va_arg(va, int)
-                                                                                          : va_arg(va, int);
+                        const int value = (flags & FLAGS_CHAR)  ? (char)      va_arg(va, int)
+                                        : (flags & FLAGS_SHORT) ? (short int) va_arg(va, int)
+                                        :                                     va_arg(va, int);
                         _ntoa_long(ctx, (unsigned int) (value > 0 ? value : 0 - value),
                                    value < 0, base, precision, width, flags);
                     }
@@ -727,11 +727,9 @@ int fmt_vfctprintf(fmt_fct_t fct, void *arg, const char *format, va_list va) {
                         _ntoa_long(ctx, va_arg(va, unsigned long), false, base, precision,
                                    width, flags);
                     } else {
-                        const unsigned int value = (flags & FLAGS_CHAR) ? (unsigned char) va_arg(va, unsigned int)
-                                                                        : (flags & FLAGS_SHORT)
-                                                                          ? (unsigned short int) va_arg(va,
-                                                                                                        unsigned int)
-                                                                          : va_arg(va, unsigned int);
+                        const unsigned int value = (flags & FLAGS_CHAR)  ? (unsigned char)      va_arg(va, unsigned int)
+                                                 : (flags & FLAGS_SHORT) ? (unsigned short int) va_arg(va, unsigned int)
+                                                 :                                              va_arg(va, unsigned int);
                         _ntoa_long(ctx, value, false, base, precision, width, flags);
                     }
                 }

--- a/pico_fmt/printf.c
+++ b/pico_fmt/printf.c
@@ -138,6 +138,8 @@ struct fmt_state {
     struct ctx          *ctx;
 };
 
+typedef void (*fmt_specifier_t)(struct fmt_state);
+
 static inline void out(char character, struct ctx *ctx) {
     if (ctx->fct) {
         ctx->fct(character, ctx->arg);
@@ -563,6 +565,29 @@ static void conv_str(struct fmt_state state);
 static void conv_ptr(struct fmt_state state);
 static void conv_pct(struct fmt_state state);
 
+static fmt_specifier_t specifier_table[0x100] = {
+    ['d'] = conv_sint,
+    ['i'] = conv_sint,
+
+    ['u'] = conv_uint,
+    ['x'] = conv_uint,
+    ['X'] = conv_uint,
+    ['o'] = conv_uint,
+    ['b'] = conv_uint,
+
+    ['f'] = conv_double,
+    ['F'] = conv_double,
+    ['e'] = conv_double,
+    ['E'] = conv_double,
+    ['g'] = conv_double,
+    ['G'] = conv_double,
+
+    ['c'] = conv_char,
+    ['s'] = conv_str,
+    ['p'] = conv_ptr,
+    ['%'] = conv_pct,
+};
+
 int fmt_vfctprintf(fmt_fct_t fct, void *arg, const char *format, va_list _va) {
     unsigned int n;
     struct ctx _ctx = {
@@ -693,42 +718,10 @@ int fmt_vfctprintf(fmt_fct_t fct, void *arg, const char *format, va_list _va) {
         // evaluate specifier
         state.specifier = *format;
         format++;
-        switch (state.specifier) {
-            case 'd' :
-            case 'i' :
-                conv_sint(state);
-                break;
-            case 'u' :
-            case 'x' :
-            case 'X' :
-            case 'o' :
-            case 'b' :
-                conv_uint(state);
-                break;
-            case 'f' :
-            case 'F' :
-            case 'e':
-            case 'E':
-            case 'g':
-            case 'G':
-                conv_double(state);
-                break;
-            case 'c' :
-                conv_char(state);
-                break;
-            case 's' :
-                conv_str(state);
-                break;
-            case 'p' :
-                conv_ptr(state);
-                break;
-            case '%' :
-                conv_pct(state);
-                break;
-
-            default :
-                out(state.specifier, state.ctx);
-                break;
+        if (specifier_table[(unsigned int) state.specifier]) {
+            specifier_table[(unsigned int) state.specifier](state);
+        } else {
+            out(state.specifier, state.ctx);
         }
     }
 

--- a/pico_fmt/printf.c
+++ b/pico_fmt/printf.c
@@ -104,18 +104,18 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 // internal flag definitions
-#define FLAGS_ZEROPAD   (1U <<  0U)
-#define FLAGS_LEFT      (1U <<  1U)
-#define FLAGS_PLUS      (1U <<  2U)
-#define FLAGS_SPACE     (1U <<  3U)
-#define FLAGS_HASH      (1U <<  4U)
-#define FLAGS_UPPERCASE (1U <<  5U)
-#define FLAGS_CHAR      (1U <<  6U)
-#define FLAGS_SHORT     (1U <<  7U)
-#define FLAGS_LONG      (1U <<  8U)
-#define FLAGS_LONG_LONG (1U <<  9U)
-#define FLAGS_PRECISION (1U << 10U)
-#define FLAGS_ADAPT_EXP (1U << 11U)
+#define FMT_FLAG_ZEROPAD   (1U <<  0U)
+#define FMT_FLAG_LEFT      (1U <<  1U)
+#define FMT_FLAG_PLUS      (1U <<  2U)
+#define FMT_FLAG_SPACE     (1U <<  3U)
+#define FMT_FLAG_HASH      (1U <<  4U)
+#define FMT_FLAG_UPPERCASE (1U <<  5U)
+#define FMT_FLAG_CHAR      (1U <<  6U)
+#define FMT_FLAG_SHORT     (1U <<  7U)
+#define FMT_FLAG_LONG      (1U <<  8U)
+#define FMT_FLAG_LONG_LONG (1U <<  9U)
+#define FMT_FLAG_PRECISION (1U << 10U)
+#define FMT_FLAG_ADAPT_EXP (1U << 11U)
 
 struct ctx {
     fmt_fct_t    fct;
@@ -170,7 +170,7 @@ static void _out_rev(struct fmt_state state, const char *buf, size_t len) {
     const size_t start_idx = state.ctx->idx;
 
     // pad spaces up to given width
-    if (!(state.flags & FLAGS_LEFT) && !(state.flags & FLAGS_ZEROPAD)) {
+    if (!(state.flags & FMT_FLAG_LEFT) && !(state.flags & FMT_FLAG_ZEROPAD)) {
         for (size_t i = len; i < state.width; i++) {
             out(' ', state.ctx);
         }
@@ -182,7 +182,7 @@ static void _out_rev(struct fmt_state state, const char *buf, size_t len) {
     }
 
     // append pad spaces up to given width
-    if (state.flags & FLAGS_LEFT) {
+    if (state.flags & FMT_FLAG_LEFT) {
         while (state.ctx->idx - start_idx < state.width) {
             out(' ', state.ctx);
         }
@@ -193,29 +193,29 @@ static void _out_rev(struct fmt_state state, const char *buf, size_t len) {
 // internal itoa format
 static void _ntoa_format(struct fmt_state state, char *buf, size_t len, bool negative, unsigned int base) {
     // pad leading zeros
-    if (!(state.flags & FLAGS_LEFT)) {
-        if (state.width && (state.flags & FLAGS_ZEROPAD) && (negative || (state.flags & (FLAGS_PLUS | FLAGS_SPACE)))) {
+    if (!(state.flags & FMT_FLAG_LEFT)) {
+        if (state.width && (state.flags & FMT_FLAG_ZEROPAD) && (negative || (state.flags & (FMT_FLAG_PLUS | FMT_FLAG_SPACE)))) {
             state.width--;
         }
         while ((len < state.precision) && (len < PICO_PRINTF_NTOA_BUFFER_SIZE)) {
             buf[len++] = '0';
         }
-        while ((state.flags & FLAGS_ZEROPAD) && (len < state.width) && (len < PICO_PRINTF_NTOA_BUFFER_SIZE)) {
+        while ((state.flags & FMT_FLAG_ZEROPAD) && (len < state.width) && (len < PICO_PRINTF_NTOA_BUFFER_SIZE)) {
             buf[len++] = '0';
         }
     }
 
     // handle hash
-    if (state.flags & FLAGS_HASH) {
-        if (!(state.flags & FLAGS_PRECISION) && len && ((len == state.precision) || (len == state.width))) {
+    if (state.flags & FMT_FLAG_HASH) {
+        if (!(state.flags & FMT_FLAG_PRECISION) && len && ((len == state.precision) || (len == state.width))) {
             len--;
             if (len && (base == 16U)) {
                 len--;
             }
         }
-        if ((base == 16U) && !(state.flags & FLAGS_UPPERCASE) && (len < PICO_PRINTF_NTOA_BUFFER_SIZE)) {
+        if ((base == 16U) && !(state.flags & FMT_FLAG_UPPERCASE) && (len < PICO_PRINTF_NTOA_BUFFER_SIZE)) {
             buf[len++] = 'x';
-        } else if ((base == 16U) && (state.flags & FLAGS_UPPERCASE) && (len < PICO_PRINTF_NTOA_BUFFER_SIZE)) {
+        } else if ((base == 16U) && (state.flags & FMT_FLAG_UPPERCASE) && (len < PICO_PRINTF_NTOA_BUFFER_SIZE)) {
             buf[len++] = 'X';
         } else if ((base == 2U) && (len < PICO_PRINTF_NTOA_BUFFER_SIZE)) {
             buf[len++] = 'b';
@@ -228,9 +228,9 @@ static void _ntoa_format(struct fmt_state state, char *buf, size_t len, bool neg
     if (len < PICO_PRINTF_NTOA_BUFFER_SIZE) {
         if (negative) {
             buf[len++] = '-';
-        } else if (state.flags & FLAGS_PLUS) {
+        } else if (state.flags & FMT_FLAG_PLUS) {
             buf[len++] = '+';  // ignore the space if the '+' exists
-        } else if (state.flags & FLAGS_SPACE) {
+        } else if (state.flags & FMT_FLAG_SPACE) {
             buf[len++] = ' ';
         }
     }
@@ -246,14 +246,14 @@ static void _ntoa_long(struct fmt_state state, unsigned long value, bool negativ
 
     // no hash for 0 values
     if (!value) {
-        state.flags &= ~FLAGS_HASH;
+        state.flags &= ~FMT_FLAG_HASH;
     }
 
     // write if precision != 0 and value is != 0
-    if (!(state.flags & FLAGS_PRECISION) || value) {
+    if (!(state.flags & FMT_FLAG_PRECISION) || value) {
         do {
             const char digit = (char) (value % base);
-            buf[len++] = (char)(digit < 10 ? '0' + digit : (state.flags & FLAGS_UPPERCASE ? 'A' : 'a') + digit - 10);
+            buf[len++] = (char)(digit < 10 ? '0' + digit : (state.flags & FMT_FLAG_UPPERCASE ? 'A' : 'a') + digit - 10);
             value /= base;
         } while (value && (len < PICO_PRINTF_NTOA_BUFFER_SIZE));
     }
@@ -271,14 +271,14 @@ static void _ntoa_long_long(struct fmt_state state, unsigned long long value, bo
 
     // no hash for 0 values
     if (!value) {
-        state.flags &= ~FLAGS_HASH;
+        state.flags &= ~FMT_FLAG_HASH;
     }
 
     // write if precision != 0 and value is != 0
-    if (!(state.flags & FLAGS_PRECISION) || value) {
+    if (!(state.flags & FMT_FLAG_PRECISION) || value) {
         do {
             const char digit = (char) (value % base);
-            buf[len++] = (char)(digit < 10 ? '0' + digit : (state.flags & FLAGS_UPPERCASE ? 'A' : 'a') + digit - 10);
+            buf[len++] = (char)(digit < 10 ? '0' + digit : (state.flags & FMT_FLAG_UPPERCASE ? 'A' : 'a') + digit - 10);
             value /= base;
         } while (value && (len < PICO_PRINTF_NTOA_BUFFER_SIZE));
     }
@@ -317,7 +317,7 @@ static void _ftoa(struct fmt_state state, double value) {
         return;
     }
     if (value > DBL_MAX) {
-        _out_rev(state, (state.flags & FLAGS_PLUS) ? "fni+" : "fni", (state.flags & FLAGS_PLUS) ? 4U : 3U);
+        _out_rev(state, (state.flags & FMT_FLAG_PLUS) ? "fni+" : "fni", (state.flags & FMT_FLAG_PLUS) ? 4U : 3U);
         return;
     }
 
@@ -338,7 +338,7 @@ static void _ftoa(struct fmt_state state, double value) {
     }
 
     // set default precision, if not set explicitly
-    if (!(state.flags & FLAGS_PRECISION)) {
+    if (!(state.flags & FMT_FLAG_PRECISION)) {
         state.precision = PICO_PRINTF_DEFAULT_FLOAT_PRECISION;
     }
     // limit precision to 9, cause a prec >= 10 can lead to overflow errors
@@ -401,8 +401,8 @@ static void _ftoa(struct fmt_state state, double value) {
     }
 
     // pad leading zeros
-    if (!(state.flags & FLAGS_LEFT) && (state.flags & FLAGS_ZEROPAD)) {
-        if (state.width && (negative || (state.flags & (FLAGS_PLUS | FLAGS_SPACE)))) {
+    if (!(state.flags & FMT_FLAG_LEFT) && (state.flags & FMT_FLAG_ZEROPAD)) {
+        if (state.width && (negative || (state.flags & (FMT_FLAG_PLUS | FMT_FLAG_SPACE)))) {
             state.width--;
         }
         while ((len < state.width) && (len < PICO_PRINTF_FTOA_BUFFER_SIZE)) {
@@ -413,9 +413,9 @@ static void _ftoa(struct fmt_state state, double value) {
     if (len < PICO_PRINTF_FTOA_BUFFER_SIZE) {
         if (negative) {
             buf[len++] = '-';
-        } else if (state.flags & FLAGS_PLUS) {
+        } else if (state.flags & FMT_FLAG_PLUS) {
             buf[len++] = '+';  // ignore the space if the '+' exists
-        } else if (state.flags & FLAGS_SPACE) {
+        } else if (state.flags & FMT_FLAG_SPACE) {
             buf[len++] = ' ';
         }
     }
@@ -441,7 +441,7 @@ static void _etoa(struct fmt_state state, double value) {
     }
 
     // default precision
-    if (!(state.flags & FLAGS_PRECISION)) {
+    if (!(state.flags & FMT_FLAG_PRECISION)) {
         state.precision = PICO_PRINTF_DEFAULT_FLOAT_PRECISION;
     }
 
@@ -479,7 +479,7 @@ static void _etoa(struct fmt_state state, double value) {
     unsigned int minwidth = ((expval < 100) && (expval > -100)) ? 4U : 5U;
 
     // in "%g" mode, "state.precision" is the number of *significant figures* not decimals
-    if (state.flags & FLAGS_ADAPT_EXP) {
+    if (state.flags & FMT_FLAG_ADAPT_EXP) {
         // do we want to fall-back to "%f" mode?
         if ((conv.U == 0) || ((value >= 1e-4) && (value < 1e6))) {
             if ((int) state.precision > expval) {
@@ -487,13 +487,13 @@ static void _etoa(struct fmt_state state, double value) {
             } else {
                 state.precision = 0;
             }
-            state.flags |= FLAGS_PRECISION;   // make sure _ftoa respects precision
+            state.flags |= FMT_FLAG_PRECISION;   // make sure _ftoa respects precision
             // no characters in exponent
             minwidth = 0U;
             expval = 0;
         } else {
             // we use one sigfig for the whole part
-            if ((state.precision > 0) && (state.flags & FLAGS_PRECISION)) {
+            if ((state.precision > 0) && (state.flags & FMT_FLAG_PRECISION)) {
                 --state.precision;
             }
         }
@@ -508,7 +508,7 @@ static void _etoa(struct fmt_state state, double value) {
         // not enough characters, so go back to default sizing
         fwidth = 0U;
     }
-    if ((state.flags & FLAGS_LEFT) && minwidth) {
+    if ((state.flags & FMT_FLAG_LEFT) && minwidth) {
         // if we're padding on the right, DON'T pad the floating part
         fwidth = 0U;
     }
@@ -523,7 +523,7 @@ static void _etoa(struct fmt_state state, double value) {
     struct fmt_state substate = {
         .width = fwidth,
         .precision = state.precision,
-        .flags = state.flags & ~FLAGS_ADAPT_EXP,
+        .flags = state.flags & ~FMT_FLAG_ADAPT_EXP,
         .ctx = state.ctx,
     };
     _ftoa(substate, negative ? -value : value);
@@ -531,17 +531,17 @@ static void _etoa(struct fmt_state state, double value) {
     // output the exponent part
     if (minwidth) {
         // output the exponential symbol
-        out((state.flags & FLAGS_UPPERCASE) ? 'E' : 'e', state.ctx);
+        out((state.flags & FMT_FLAG_UPPERCASE) ? 'E' : 'e', state.ctx);
         // output the exponent value
         struct fmt_state substate = {
             .width = minwidth - 1,
             .precision = 0,
-            .flags = FLAGS_ZEROPAD | FLAGS_PLUS,
+            .flags = FMT_FLAG_ZEROPAD | FMT_FLAG_PLUS,
             .ctx = state.ctx,
         };
         _ntoa_long(substate, (unsigned int)((expval < 0) ? -expval : expval), expval < 0, 10);
         // might need to right-pad spaces
-        if (state.flags & FLAGS_LEFT) {
+        if (state.flags & FMT_FLAG_LEFT) {
             while (state.ctx->idx - start_idx < state.width) out(' ', state.ctx);
         }
     }
@@ -578,27 +578,27 @@ int fmt_vfctprintf(fmt_fct_t fct, void *arg, const char *format, va_list va) {
         do {
             switch (*format) {
                 case '0':
-                    state.flags |= FLAGS_ZEROPAD;
+                    state.flags |= FMT_FLAG_ZEROPAD;
                     format++;
                     n = 1U;
                     break;
                 case '-':
-                    state.flags |= FLAGS_LEFT;
+                    state.flags |= FMT_FLAG_LEFT;
                     format++;
                     n = 1U;
                     break;
                 case '+':
-                    state.flags |= FLAGS_PLUS;
+                    state.flags |= FMT_FLAG_PLUS;
                     format++;
                     n = 1U;
                     break;
                 case ' ':
-                    state.flags |= FLAGS_SPACE;
+                    state.flags |= FMT_FLAG_SPACE;
                     format++;
                     n = 1U;
                     break;
                 case '#':
-                    state.flags |= FLAGS_HASH;
+                    state.flags |= FMT_FLAG_HASH;
                     format++;
                     n = 1U;
                     break;
@@ -615,7 +615,7 @@ int fmt_vfctprintf(fmt_fct_t fct, void *arg, const char *format, va_list va) {
         } else if (*format == '*') {
             const int w = va_arg(va, int);
             if (w < 0) {
-                state.flags |= FLAGS_LEFT;    // reverse padding
+                state.flags |= FMT_FLAG_LEFT;    // reverse padding
                 state.width = (unsigned int) -w;
             } else {
                 state.width = (unsigned int) w;
@@ -626,7 +626,7 @@ int fmt_vfctprintf(fmt_fct_t fct, void *arg, const char *format, va_list va) {
         // evaluate precision field
         state.precision = 0U;
         if (*format == '.') {
-            state.flags |= FLAGS_PRECISION;
+            state.flags |= FMT_FLAG_PRECISION;
             format++;
             if (_is_digit(*format)) {
                 state.precision = _atoi(&format);
@@ -640,33 +640,33 @@ int fmt_vfctprintf(fmt_fct_t fct, void *arg, const char *format, va_list va) {
         // evaluate length field
         switch (*format) {
             case 'l' :
-                state.flags |= FLAGS_LONG;
+                state.flags |= FMT_FLAG_LONG;
                 format++;
                 if (*format == 'l') {
-                    state.flags |= FLAGS_LONG_LONG;
+                    state.flags |= FMT_FLAG_LONG_LONG;
                     format++;
                 }
                 break;
             case 'h' :
-                state.flags |= FLAGS_SHORT;
+                state.flags |= FMT_FLAG_SHORT;
                 format++;
                 if (*format == 'h') {
-                    state.flags |= FLAGS_CHAR;
+                    state.flags |= FMT_FLAG_CHAR;
                     format++;
                 }
                 break;
 #if PICO_PRINTF_SUPPORT_PTRDIFF_T
             case 't' :
-                state.flags |= (sizeof(ptrdiff_t) == sizeof(long) ? FLAGS_LONG : FLAGS_LONG_LONG);
+                state.flags |= (sizeof(ptrdiff_t) == sizeof(long) ? FMT_FLAG_LONG : FMT_FLAG_LONG_LONG);
                 format++;
                 break;
 #endif
             case 'j' :
-                state.flags |= (sizeof(intmax_t) == sizeof(long) ? FLAGS_LONG : FLAGS_LONG_LONG);
+                state.flags |= (sizeof(intmax_t) == sizeof(long) ? FMT_FLAG_LONG : FMT_FLAG_LONG_LONG);
                 format++;
                 break;
             case 'z' :
-                state.flags |= (sizeof(size_t) == sizeof(long) ? FLAGS_LONG : FLAGS_LONG_LONG);
+                state.flags |= (sizeof(size_t) == sizeof(long) ? FMT_FLAG_LONG : FMT_FLAG_LONG_LONG);
                 format++;
                 break;
             default :
@@ -692,51 +692,51 @@ int fmt_vfctprintf(fmt_fct_t fct, void *arg, const char *format, va_list va) {
                     base = 2U;
                 } else {
                     base = 10U;
-                    state.flags &= ~FLAGS_HASH;   // no hash for dec format
+                    state.flags &= ~FMT_FLAG_HASH;   // no hash for dec format
                 }
                 // uppercase
                 if (*format == 'X') {
-                    state.flags |= FLAGS_UPPERCASE;
+                    state.flags |= FMT_FLAG_UPPERCASE;
                 }
 
                 // no plus or space flag for u, x, X, o, b
                 if ((*format != 'i') && (*format != 'd')) {
-                    state.flags &= ~(FLAGS_PLUS | FLAGS_SPACE);
+                    state.flags &= ~(FMT_FLAG_PLUS | FMT_FLAG_SPACE);
                 }
 
                 // ignore '0' flag when precision is given
-                if (state.flags & FLAGS_PRECISION) {
-                    state.flags &= ~FLAGS_ZEROPAD;
+                if (state.flags & FMT_FLAG_PRECISION) {
+                    state.flags &= ~FMT_FLAG_ZEROPAD;
                 }
 
                 // convert the integer
                 if ((*format == 'i') || (*format == 'd')) {
                     // signed
-                    if (state.flags & FLAGS_LONG_LONG) {
+                    if (state.flags & FMT_FLAG_LONG_LONG) {
 #if PICO_PRINTF_SUPPORT_LONG_LONG
                         const long long value = va_arg(va, long long);
                         _ntoa_long_long(state, (unsigned long long) (value > 0 ? value : 0 - value), value < 0, base);
 #endif
-                    } else if (state.flags & FLAGS_LONG) {
+                    } else if (state.flags & FMT_FLAG_LONG) {
                         const long value = va_arg(va, long);
                         _ntoa_long(state, (unsigned long) (value > 0 ? value : 0 - value), value < 0, base);
                     } else {
-                        const int value = (state.flags & FLAGS_CHAR)  ? (char)      va_arg(va, int)
-                                        : (state.flags & FLAGS_SHORT) ? (short int) va_arg(va, int)
+                        const int value = (state.flags & FMT_FLAG_CHAR)  ? (char)      va_arg(va, int)
+                                        : (state.flags & FMT_FLAG_SHORT) ? (short int) va_arg(va, int)
                                         :                                           va_arg(va, int);
                         _ntoa_long(state, (unsigned int) (value > 0 ? value : 0 - value), value < 0, base);
                     }
                 } else {
                     // unsigned
-                    if (state.flags & FLAGS_LONG_LONG) {
+                    if (state.flags & FMT_FLAG_LONG_LONG) {
 #if PICO_PRINTF_SUPPORT_LONG_LONG
                         _ntoa_long_long(state, va_arg(va, unsigned long long), false, base);
 #endif
-                    } else if (state.flags & FLAGS_LONG) {
+                    } else if (state.flags & FMT_FLAG_LONG) {
                         _ntoa_long(state, va_arg(va, unsigned long), false, base);
                     } else {
-                        const unsigned int value = (state.flags & FLAGS_CHAR)  ? (unsigned char)      va_arg(va, unsigned int)
-                                                 : (state.flags & FLAGS_SHORT) ? (unsigned short int) va_arg(va, unsigned int)
+                        const unsigned int value = (state.flags & FMT_FLAG_CHAR)  ? (unsigned char)      va_arg(va, unsigned int)
+                                                 : (state.flags & FMT_FLAG_SHORT) ? (unsigned short int) va_arg(va, unsigned int)
                                                  :                                                    va_arg(va, unsigned int);
                         _ntoa_long(state, value, false, base);
                     }
@@ -747,7 +747,7 @@ int fmt_vfctprintf(fmt_fct_t fct, void *arg, const char *format, va_list va) {
             case 'f' :
             case 'F' :
 #if PICO_PRINTF_SUPPORT_FLOAT
-                if (*format == 'F') state.flags |= FLAGS_UPPERCASE;
+                if (*format == 'F') state.flags |= FMT_FLAG_UPPERCASE;
                 _ftoa(state, va_arg(va, double));
 #else
                 for(int i=0;i<2;i++) out('?', state.ctx);
@@ -760,8 +760,8 @@ int fmt_vfctprintf(fmt_fct_t fct, void *arg, const char *format, va_list va) {
             case 'g':
             case 'G':
 #if PICO_PRINTF_SUPPORT_FLOAT && PICO_PRINTF_SUPPORT_EXPONENTIAL
-                if ((*format == 'g') || (*format == 'G')) state.flags |= FLAGS_ADAPT_EXP;
-                if ((*format == 'E') || (*format == 'G')) state.flags |= FLAGS_UPPERCASE;
+                if ((*format == 'g') || (*format == 'G')) state.flags |= FMT_FLAG_ADAPT_EXP;
+                if ((*format == 'E') || (*format == 'G')) state.flags |= FMT_FLAG_UPPERCASE;
                 _etoa(state, va_arg(va, double));
 #else
                 for(int i=0;i<2;i++) out('?', state.ctx);
@@ -772,7 +772,7 @@ int fmt_vfctprintf(fmt_fct_t fct, void *arg, const char *format, va_list va) {
             case 'c' : {
                 unsigned int l = 1U;
                 // pre padding
-                if (!(state.flags & FLAGS_LEFT)) {
+                if (!(state.flags & FMT_FLAG_LEFT)) {
                     while (l++ < state.width) {
                         out(' ', state.ctx);
                     }
@@ -780,7 +780,7 @@ int fmt_vfctprintf(fmt_fct_t fct, void *arg, const char *format, va_list va) {
                 // char output
                 out((char) va_arg(va, int), state.ctx);
                 // post padding
-                if (state.flags & FLAGS_LEFT) {
+                if (state.flags & FMT_FLAG_LEFT) {
                     while (l++ < state.width) {
                         out(' ', state.ctx);
                     }
@@ -793,20 +793,20 @@ int fmt_vfctprintf(fmt_fct_t fct, void *arg, const char *format, va_list va) {
                 const char *p = va_arg(va, char*);
                 unsigned int l = _strnlen_s(p, state.precision ? state.precision : (size_t) -1);
                 // pre padding
-                if (state.flags & FLAGS_PRECISION) {
+                if (state.flags & FMT_FLAG_PRECISION) {
                     l = (l < state.precision ? l : state.precision);
                 }
-                if (!(state.flags & FLAGS_LEFT)) {
+                if (!(state.flags & FMT_FLAG_LEFT)) {
                     while (l++ < state.width) {
                         out(' ', state.ctx);
                     }
                 }
                 // string output
-                while ((*p != 0) && (!(state.flags & FLAGS_PRECISION) || state.precision--)) {
+                while ((*p != 0) && (!(state.flags & FMT_FLAG_PRECISION) || state.precision--)) {
                     out(*(p++), state.ctx);
                 }
                 // post padding
-                if (state.flags & FLAGS_LEFT) {
+                if (state.flags & FMT_FLAG_LEFT) {
                     while (l++ < state.width) {
                         out(' ', state.ctx);
                     }
@@ -817,7 +817,7 @@ int fmt_vfctprintf(fmt_fct_t fct, void *arg, const char *format, va_list va) {
 
             case 'p' : {
                 state.width = sizeof(void *) * 2U;
-                state.flags |= FLAGS_ZEROPAD | FLAGS_UPPERCASE;
+                state.flags |= FMT_FLAG_ZEROPAD | FMT_FLAG_UPPERCASE;
 #if PICO_PRINTF_SUPPORT_LONG_LONG
                 const bool is_ll = sizeof(uintptr_t) == sizeof(long long);
                 if (is_ll) {

--- a/pico_fmt/printf.c
+++ b/pico_fmt/printf.c
@@ -104,12 +104,12 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 // internal flag definitions
-#define FMT_FLAG_ZEROPAD   (1U <<  0U)
-#define FMT_FLAG_LEFT      (1U <<  1U)
-#define FMT_FLAG_PLUS      (1U <<  2U)
-#define FMT_FLAG_SPACE     (1U <<  3U)
-#define FMT_FLAG_HASH      (1U <<  4U)
-#define FMT_FLAG_PRECISION (1U << 10U)
+#define FMT_FLAG_ZEROPAD   (1U <<  0U) // '0'
+#define FMT_FLAG_LEFT      (1U <<  1U) // '-'
+#define FMT_FLAG_PLUS      (1U <<  2U) // '+'
+#define FMT_FLAG_SPACE     (1U <<  3U) // ' '
+#define FMT_FLAG_HASH      (1U <<  4U) // '#'
+#define FMT_FLAG_PRECISION (1U << 10U) // state.precision is set
 
 enum fmt_size {
     FMT_SIZE_CHAR,      // "hh"


### PR DESCRIPTION
First, a bunch of commits reworking the internal API to support this change.

Then, a final commit adding `<pico/fmt_install.h>:fmt_install()` to add new `%specifier` characters.